### PR TITLE
Make --request-info an argument

### DIFF
--- a/collector/phpspy.go
+++ b/collector/phpspy.go
@@ -25,11 +25,12 @@ func New(cfg *config.Config) *PhpSpy {
 // Returns a channel that will receive parsed traces and any error that occurred
 func (ps *PhpSpy) Start() (<-chan *Trace, error) {
 	// Construct phpspy command with configuration parameters
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("phpspy --rate-hz=%d --pgrep='-x \"(php-fpm.*|^php$)\"' --buffer-size=%d --max-depth=%d --threads=%d --request-info=qcup",
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("phpspy --rate-hz=%d --pgrep='-x \"(php-fpm.*|^php$)\"' --buffer-size=%d --max-depth=%d --threads=%d --request-info=%d",
 		ps.config.RateHz,
 		ps.config.PhpspyBufferSize,
 		ps.config.PhpspyMaxDepth,
-		ps.config.PhpspyThreads))
+		ps.config.PhpspyThreads,
+		ps.config.PhpspyRequestInfo))
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/collector/phpspy.go
+++ b/collector/phpspy.go
@@ -25,7 +25,7 @@ func New(cfg *config.Config) *PhpSpy {
 // Returns a channel that will receive parsed traces and any error that occurred
 func (ps *PhpSpy) Start() (<-chan *Trace, error) {
 	// Construct phpspy command with configuration parameters
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("phpspy --rate-hz=%d --pgrep='-x \"(php-fpm.*|^php$)\"' --buffer-size=%d --max-depth=%d --threads=%d --request-info=%d",
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("phpspy --rate-hz=%d --pgrep='-x \"(php-fpm.*|^php$)\"' --buffer-size=%d --max-depth=%d --threads=%d --request-info=%s",
 		ps.config.RateHz,
 		ps.config.PhpspyBufferSize,
 		ps.config.PhpspyMaxDepth,

--- a/config/config.go
+++ b/config/config.go
@@ -8,29 +8,31 @@ type Config struct {
 	AppName      string
 	Tags         map[string]string
 	Debug        bool
-	
+
 	// Profiling settings
 	RateHz          int
 	Interval        float64
 	BatchLimit      int
 	ConcurrentLimit int
 	ExcludePattern  string
-	
+
 	// PHP-specific settings
-	PhpspyBufferSize int
-	PhpspyMaxDepth   int
-	PhpspyThreads    int
+	PhpspyBufferSize  int
+	PhpspyMaxDepth    int
+	PhpspyThreads     int
+	PhpspyRequestInfo string
 }
 
 // NewDefault returns a new default config
 func NewDefault() *Config {
 	return &Config{
-		RateHz:           400,
-		Interval:         0.1,
-		BatchLimit:       50000,
-		ConcurrentLimit:  1,
-		PhpspyBufferSize: 131072,
-		PhpspyMaxDepth:   -1,
-		PhpspyThreads:    64,
+		RateHz:            400,
+		Interval:          0.1,
+		BatchLimit:        50000,
+		ConcurrentLimit:   1,
+		PhpspyBufferSize:  131072,
+		PhpspyMaxDepth:    -1,
+		PhpspyThreads:     64,
+		PhpspyRequestInfo: "qcup",
 	}
 }

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func main() {
 	flag.IntVar(&cfg.PhpspyBufferSize, "phpspyBufferSize", cfg.PhpspyBufferSize, "Size of phpspy's internal buffer")
 	flag.IntVar(&cfg.PhpspyMaxDepth, "phpspyMaxDepth", cfg.PhpspyMaxDepth, "Maximum stack trace depth")
 	flag.IntVar(&cfg.PhpspyThreads, "phpspyThreads", cfg.PhpspyThreads, "Number of phpspy worker threads")
-	flag.StringVar(&cfg.PhpspyRequestInfo, "phpspyRequestInfo", "qcup", "Request info to include in traces (default: qcup)")
+	flag.StringVar(&cfg.PhpspyRequestInfo, "phpspyRequestInfo", cfg.PhpspyRequestInfo, "Request info to include in traces")
 
 	flag.BoolVar(&cfg.Debug, "debug", false, "Enable debug logging")
 

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 	flag.IntVar(&cfg.PhpspyBufferSize, "phpspyBufferSize", cfg.PhpspyBufferSize, "Size of phpspy's internal buffer")
 	flag.IntVar(&cfg.PhpspyMaxDepth, "phpspyMaxDepth", cfg.PhpspyMaxDepth, "Maximum stack trace depth")
 	flag.IntVar(&cfg.PhpspyThreads, "phpspyThreads", cfg.PhpspyThreads, "Number of phpspy worker threads")
+	flag.StringVar(&cfg.PhpspyRequestInfo, "phpspyRequestInfo", "qcup", "Request info to include in traces (default: qcup)")
 
 	flag.BoolVar(&cfg.Debug, "debug", false, "Enable debug logging")
 


### PR DESCRIPTION
As it turned out pyroscope didn't liked it when there are too many cookies, which is probably an issue with the state of current frameworks and cms's. From the looks of it they get cut off and pyroscope complains about invalid utf8. .... Also I don't think it is of much use to make all cookies and values a label in pyroscope. Besides this probably leads to a huge index as everything is biased on the exact names and values of all cookies! [1]

1. I base this on the tip to use as few labels als possible in Loki to keep the index as small as possible, but guess Pyroscope must has have similar issues.